### PR TITLE
Fix: Ensure DTMF result is returned by adding additional condition

### DIFF
--- a/channel.ts
+++ b/channel.ts
@@ -345,7 +345,15 @@ export class AGIChannel extends events.EventEmitter {
             this._socket && this._socket.end();
           }
           const final = response.data.match(/\((.*?)\)/);
-          resolve(final ? final[1] : response.data);
+          let dataResponse: any = null;
+          if (final) {
+            dataResponse = final[1];
+          } else if (response.data) {
+            dataResponse = response.data;
+          } else {
+            dataResponse = response.result;
+          }
+          resolve(dataResponse);
         });
         if (this._socket.writable) {
           this._socket.write(command + "\n", "utf8");


### PR DESCRIPTION
### Description:

This pull request addresses an issue where the result from the DTMF function was not being returned due to a missing condition. The function now includes a new condition that ensures the correct result is always returned.

### Changes:
- Updated the function logic to handle cases where `response.data` or `response.result` is not properly returned.
- Added a new condition to ensure DTMF correctly returns either the matched data, `response.data`, or `response.result`.
